### PR TITLE
Removed file logger from xpedite log config

### DIFF
--- a/scripts/lib/logger/conf.ini
+++ b/scripts/lib/logger/conf.ini
@@ -7,7 +7,7 @@ handlers=file
 
 [logger_xpedite]
 level=DEBUG
-handlers=stream,file
+handlers=stream
 propogate=0
 qualname=xpedite
 


### PR DESCRIPTION
Removed file logger from xpedite log config to stop duplicate logging when using root logger