### PR TITLE
Check whole record for hugepage mapping.

### DIFF
--- a/lib/xpedite/util/AddressSpace.C
+++ b/lib/xpedite/util/AddressSpace.C
@@ -55,20 +55,19 @@ namespace xpedite { namespace util {
       while(stream) {
         stream >> file;
       }
+      if(file[0] != '/' && file[0] != '[') {
+        // Anonymous memory segment
+        file = anonymousSegment;
+      }
     }
 
+    bool isPositionIndependent {file != executablePath_ && file != anonymousSegment};
     std::istringstream stream {range};
     std::string begin, end;
     if(std::getline(stream, begin, '-') && std::getline(stream, end, ' ')) {
       auto b = reinterpret_cast<AddressSpace::Segment::Pointer>(std::stoull(begin, 0, 16));
       auto e = reinterpret_cast<AddressSpace::Segment::Pointer>(std::stoull(end, 0, 16));
-      auto isHugePage = isMappingHugePage(e - b, file);
-
-      if(file[0] != '/' && file[0] != '[') {
-        // Anonymous memory segment
-        file = anonymousSegment;
-      }
-      bool isPositionIndependent {file != executablePath_ && file != anonymousSegment};
+      auto isHugePage = isMappingHugePage(e - b, record);
       return AddressSpace::Segment {b, e, flags[0] == 'r', flags[1] == 'w', flags[2] == 'x', isPositionIndependent, isHugePage, file};
     }
     return {};


### PR DESCRIPTION
The assumption while parsing a record segment is that the last file string will not have spaces. But thats not correct. In case of hugepages the file attribute is - "anon_hugepage (deleted)". So because of the assumption file is evaluating to "(deleted)" i.e. last string after space.