### PR TITLE
Fix Issue #90 Model Name is a combination of extended model and model…

### DIFF
--- a/scripts/lib/xpedite/util/__init__.py
+++ b/scripts/lib/xpedite/util/__init__.py
@@ -213,7 +213,8 @@ def getCpuInfo():
 def getCpuId(cpuInfo=None):
   """Returns cpu model for localhost"""
   cpuInfo = cpuInfo if cpuInfo else getCpuInfo()
-  return '{}-{}-{:02X}'.format(cpuInfo['vendor_id'], cpuInfo['family'], cpuInfo['model'])
+  model = (cpuInfo['extended_model'] << 4 | cpuInfo['model'])
+  return '{}-{}-{:02X}'.format(cpuInfo['vendor_id'], cpuInfo['family'], model)
 
 def meminfo(remoteConnection=None):
   """


### PR DESCRIPTION
[Mapfile](https://download.01.org/perfmon/mapfile.csv) used to locate events database is a key comprising of model name which is same as model name returned by `lscpu` tool.

But the `py-cpuinfo` package directly returns the `model` and `extended model` of the `CPUID` [output](https://en.wikipedia.org/wiki/CPUID#CPUID_usage_from_high-level_languages).

`Model` returned in lscpu and used in map file is `(extended_model << 4 | model)` of cpuid values.
